### PR TITLE
IC2ACTIVE=$(ls /dev/*i2c*)->IC2ACTIVE=$(ls /dev/i2c-1)

### DIFF
--- a/rtc
+++ b/rtc
@@ -7,7 +7,7 @@
 
 clear;echo;echo
 
-IC2ACTIVE=$(ls /dev/*i2c*)
+IC2ACTIVE=$(ls /dev/i2c-1)
 
 if [ $IC2ACTIVE = "/dev/i2c-1" ]
 then


### PR DESCRIPTION
If IC2ACTIVE=$(ls /dev/*i2c*)  is used the subsequent if statement if [ $IC2ACTIVE = "/dev/i2c-1" ] will be false if more than one i2c devices exists even if one of them is i2c-1
e. g. if the following devices exist /dev/i2c-1  /dev/i2c-20  /dev/i2c-21
the test will fail when it should succeed